### PR TITLE
feat: Drop support for ROS Crystal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,5 @@
 version: 2
 jobs:
-  crystal:
-    docker:
-    - image: tiryoh/ubuntu:bionic-dev
-    steps:
-    - checkout
-    - run:
-        name: Install
-        command: sed -e 's/^\(CHOOSE_ROS_DISTRO=.*\)/#\1\nCHOOSE_ROS_DISTRO=crystal/g' -i run.sh && ./run.sh
-    - run:
-        name: Test
-        command: sed -e 's/dashing/crystal/g' -i tutorial.sh && bash -c "$(head -n -2 ./tutorial.sh && echo 'which ros2')"
   dashing:
     docker:
     - image: tiryoh/ubuntu:bionic-dev
@@ -38,7 +27,6 @@ workflows:
   version: 2
   commit-workflow:
     jobs:
-      - crystal
       - dashing
       - eloquent
   scheduled-workflow:
@@ -50,6 +38,5 @@ workflows:
               only:
                 - master
     jobs:
-      - crystal
       - dashing
       - eloquent

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   skip:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - run: echo "[Skip CI] ${{ contains(github.event.head_commit.message, '[skip ci]') }}"
 
@@ -27,9 +27,9 @@ jobs:
     if: contains(github.event.head_commit.message, '[skip ci]') == false
     strategy:
       matrix:
-        ros-distro: [crystal, dashing, eloquent]
+        ros-distro: [dashing, eloquent]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Run the install script
         run: |
           sed -e 's/^\(CHOOSE_ROS_DISTRO=.*\)/#\1\nCHOOSE_ROS_DISTRO=$ROS_DISTRO/g' -i run.sh

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ By default, `run.sh` will install `ros-dashing-desktop`.
 If you need to install another package, edit line8-9 in `run.sh`.
 
 ```sh
-CHOOSE_ROS_DISTRO=dashing # or crystal or eloquent
+CHOOSE_ROS_DISTRO=dashing # or eloquent
 INSTALL_PACKAGE=desktop # or ros-base
 ```
 
-For example, if you want to install ros-base package of ROS 2 Crystal,
+For example, if you want to install ros-base package of ROS 2 Eloquent,
 edit like the followings.
 
 ```sh
-CHOOSE_ROS_DISTRO=crystal # or crystal or eloquent
+CHOOSE_ROS_DISTRO=eloquent # or eloquent
 INSTALL_PACKAGE=ros-base # or ros-base
 ```
 

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ set -eu
 # by Open Robotics, licensed under CC-BY-4.0
 # source: https://github.com/ros2/ros2_documentation
 
-CHOOSE_ROS_DISTRO=dashing # or crystal or eloquent
+CHOOSE_ROS_DISTRO=dashing # or eloquent
 INSTALL_PACKAGE=desktop # or ros-base
 
 sudo apt update


### PR DESCRIPTION
ROS Crystal is no longer supported (EOL Dec. 2019).
https://index.ros.org/doc/ros2/Releases/Release-Crystal-Clemmys/