### PR TITLE
fix: Check rosdep sources list before initializing to avoid error on rosdep init

### DIFF
--- a/ros2-dashing-desktop-main.sh
+++ b/ros2-dashing-desktop-main.sh
@@ -19,6 +19,7 @@ sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete
 sudo apt-get install -y python3-colcon-common-extensions
 sudo apt-get install -y python-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+[ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update
 grep -F "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" ~/.bashrc ||

--- a/ros2-dashing-ros-base-main.sh
+++ b/ros2-dashing-ros-base-main.sh
@@ -19,6 +19,7 @@ sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete
 sudo apt-get install -y python3-colcon-common-extensions
 sudo apt-get install -y python-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+[ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update
 grep -F "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" ~/.bashrc ||

--- a/ros2-eloquent-desktop-main.sh
+++ b/ros2-eloquent-desktop-main.sh
@@ -19,6 +19,7 @@ sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete
 sudo apt-get install -y python3-colcon-common-extensions
 sudo apt-get install -y python-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+[ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update
 grep -F "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" ~/.bashrc ||

--- a/ros2-eloquent-ros-base-main.sh
+++ b/ros2-eloquent-ros-base-main.sh
@@ -19,6 +19,7 @@ sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete
 sudo apt-get install -y python3-colcon-common-extensions
 sudo apt-get install -y python-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+[ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update
 grep -F "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" ~/.bashrc ||

--- a/ros2-foxy-desktop-main.sh
+++ b/ros2-foxy-desktop-main.sh
@@ -19,6 +19,7 @@ sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete
 sudo apt-get install -y python3-colcon-common-extensions
 sudo apt-get install -y python3-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+[ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update
 grep -F "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" ~/.bashrc ||

--- a/ros2-foxy-ros-base-main.sh
+++ b/ros2-foxy-ros-base-main.sh
@@ -19,6 +19,7 @@ sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete
 sudo apt-get install -y python3-colcon-common-extensions
 sudo apt-get install -y python3-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+[ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update
 grep -F "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" ~/.bashrc ||


### PR DESCRIPTION
`sudo rosdep init` causes the following error when rosdep has already installed by using ROS 1.

```
ERROR: default sources list file already exists:
	/etc/ros/rosdep/sources.list.d/20-default.list
Please delete if you wish to re-initialize
```