### PR TITLE
chore: Update document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 unofficial ROS2 install script for Ubuntu
 
-Access https://index.ros.org/doc/ros2/Installation/ to get the updated information.
+Access https://docs.ros.org/en/jazzy/Installation.html to get the updated information.
 
 ROS 1 version: https://github.com/Tiryoh/ros_setup_scripts_ubuntu
 
@@ -98,10 +98,12 @@ limitations under the License.
 
 ### Acknowledgements
 
-`run.sh` is based on https://index.ros.org/doc/ros2/Installation/Crystal/Linux-Install-Debians/
+`run.sh` is based on [https://index.ros.org/doc/ros2/Installation/Crystal/Linux-Install-Debians/](https://web.archive.org/web/20190618134850/https://index.ros.org//doc/ros2/Installation/Crystal/Linux-Install-Debians/)
 by Open Robotics, licensed under CC-BY-4.0.  
 
-`tutorial.sh` is based on https://index.ros.org/doc/ros2/Tutorials/Colcon-Tutorial/
+`tutorial.sh` is based on [https://index.ros.org/doc/ros2/Tutorials/Colcon-Tutorial/](https://web.archive.org/web/20190618134901/https://index.ros.org/doc/ros2/Tutorials/Colcon-Tutorial/)
 by Open Robotics, licensed under CC-BY-4.0.  
 
 source: https://github.com/ros2/ros2_documentation
+
+Access https://docs.ros.org/en/jazzy/Installation.html to get the updated information.

--- a/ros2-humble-desktop-main.sh
+++ b/ros2-humble-desktop-main.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-# Copyright 2019-2022 Tiryoh
+# Copyright 2019-2024 Tiryoh
 # https://github.com/Tiryoh/ros2_setup_scripts_ubuntu
 # Licensed under the Apache License, Version 2.0
 #
-# REF: https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html
+# REF: https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
 # by Open Robotics, licensed under CC-BY-4.0
 # source: https://github.com/ros2/ros2_documentation
 
@@ -54,7 +54,7 @@ sudo apt-get update
 sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete python3-colcon-clean
 sudo apt-get install -y python3-colcon-common-extensions
-sudo apt-get install -y python3-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+sudo apt-get install -y python3-rosdep python3-vcstool
 [ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update

--- a/ros2-humble-ros-base-main.sh
+++ b/ros2-humble-ros-base-main.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-# Copyright 2019-2022 Tiryoh
+# Copyright 2019-2024 Tiryoh
 # https://github.com/Tiryoh/ros2_setup_scripts_ubuntu
 # Licensed under the Apache License, Version 2.0
 #
-# REF: https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html
+# REF: https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
 # by Open Robotics, licensed under CC-BY-4.0
 # source: https://github.com/ros2/ros2_documentation
 
@@ -54,7 +54,7 @@ sudo apt-get update
 sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete python3-colcon-clean
 sudo apt-get install -y python3-colcon-common-extensions
-sudo apt-get install -y python3-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+sudo apt-get install -y python3-rosdep python3-vcstool
 [ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update

--- a/ros2-iron-desktop-main.sh
+++ b/ros2-iron-desktop-main.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-# Copyright 2019-2023 Tiryoh
+# Copyright 2019-2024 Tiryoh
 # https://github.com/Tiryoh/ros2_setup_scripts_ubuntu
 # Licensed under the Apache License, Version 2.0
 #
-# REF: https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html
+# REF: https://docs.ros.org/en/iron/Installation/Ubuntu-Install-Debians.html
 # by Open Robotics, licensed under CC-BY-4.0
 # source: https://github.com/ros2/ros2_documentation
 
@@ -54,7 +54,7 @@ sudo apt-get update
 sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete python3-colcon-clean
 sudo apt-get install -y python3-colcon-common-extensions
-sudo apt-get install -y python3-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+sudo apt-get install -y python3-rosdep python3-vcstool
 [ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update

--- a/ros2-iron-ros-base-main.sh
+++ b/ros2-iron-ros-base-main.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-# Copyright 2019-2023 Tiryoh
+# Copyright 2019-2024 Tiryoh
 # https://github.com/Tiryoh/ros2_setup_scripts_ubuntu
 # Licensed under the Apache License, Version 2.0
 #
-# REF: https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html
+# REF: https://docs.ros.org/en/iron/Installation/Ubuntu-Install-Debians.html
 # by Open Robotics, licensed under CC-BY-4.0
 # source: https://github.com/ros2/ros2_documentation
 
@@ -54,7 +54,7 @@ sudo apt-get update
 sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete python3-colcon-clean
 sudo apt-get install -y python3-colcon-common-extensions
-sudo apt-get install -y python3-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+sudo apt-get install -y python3-rosdep python3-vcstool
 [ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update

--- a/ros2-jazzy-desktop-main.sh
+++ b/ros2-jazzy-desktop-main.sh
@@ -5,7 +5,7 @@ set -eu
 # https://github.com/Tiryoh/ros2_setup_scripts_ubuntu
 # Licensed under the Apache License, Version 2.0
 #
-# REF: https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html
+# REF: https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html
 # by Open Robotics, licensed under CC-BY-4.0
 # source: https://github.com/ros2/ros2_documentation
 
@@ -48,7 +48,7 @@ sudo apt-get update
 sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete python3-colcon-clean
 sudo apt-get install -y python3-colcon-common-extensions
-sudo apt-get install -y python3-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+sudo apt-get install -y python3-rosdep python3-vcstool
 [ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update

--- a/ros2-jazzy-ros-base-main.sh
+++ b/ros2-jazzy-ros-base-main.sh
@@ -5,7 +5,7 @@ set -eu
 # https://github.com/Tiryoh/ros2_setup_scripts_ubuntu
 # Licensed under the Apache License, Version 2.0
 #
-# REF: https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html
+# REF: https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html
 # by Open Robotics, licensed under CC-BY-4.0
 # source: https://github.com/ros2/ros2_documentation
 
@@ -48,7 +48,7 @@ sudo apt-get update
 sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt-get install -y python3-argcomplete python3-colcon-clean
 sudo apt-get install -y python3-colcon-common-extensions
-sudo apt-get install -y python3-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+sudo apt-get install -y python3-rosdep python3-vcstool
 [ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init
 rosdep update

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-# Copyright 2019-2023 Tiryoh
+# Copyright 2019-2024 Tiryoh
 # https://github.com/Tiryoh/ros2_setup_scripts_ubuntu
 # Licensed under the Apache License, Version 2.0
 #
-# REF: https://index.ros.org/doc/ros2/Installation/Linux-Install-Debians/
+# REF: https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html
 # by Open Robotics, licensed under CC-BY-4.0
 # source: https://github.com/ros2/ros2_documentation
 
@@ -21,9 +21,9 @@ sudo apt install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
 sudo apt install -y python3-argcomplete
 sudo apt install -y python3-colcon-common-extensions
 if [ "$(lsb_release -cs)" = "bionic" ]; then
-	sudo apt install -y python-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+	sudo apt install -y python-rosdep python3-vcstool
 else
-	sudo apt install -y python3-rosdep python3-vcstool # https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/
+	sudo apt install -y python3-rosdep python3-vcstool
 fi
 [ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
 sudo rosdep init


### PR DESCRIPTION
Thanks to @CursedRock17, we found that some of the links in the document and comments were invalid.

I have corrected the URLs for the Humble version and later scripts.

fixes https://github.com/Tiryoh/ros2_setup_scripts_ubuntu/issues/63