### PR TITLE
ci: Pin Python version in CI workflows to fix colcon test failures

### DIFF
--- a/.github/workflows/eol-installers.yml
+++ b/.github/workflows/eol-installers.yml
@@ -23,6 +23,9 @@ on:
   schedule:
     - cron: "0 1 * * 1"
 
+env:
+  PATH: /usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin
+
 jobs:
   # os-check-on-ubuntu-bionic:
   #   runs-on: ubuntu-18.04
@@ -148,10 +151,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
       - name: Run the install script
         run: |
           ./ros2-iron-ros-base-main.sh
@@ -165,10 +164,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
       - name: Run the install script
         run: |
           ./ros2-iron-desktop-main.sh

--- a/.github/workflows/eol-installers.yml
+++ b/.github/workflows/eol-installers.yml
@@ -148,6 +148,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Run the install script
         run: |
           ./ros2-iron-ros-base-main.sh
@@ -161,6 +165,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Run the install script
         run: |
           ./ros2-iron-desktop-main.sh

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -44,6 +44,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Run the install script
         run: |
           ./ros2-humble-ros-base-main.sh
@@ -57,6 +61,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Run the install script
         run: |
           ./ros2-humble-desktop-main.sh
@@ -69,6 +77,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Run the install script
         run: |
           ./ros2-jazzy-ros-base-main.sh
@@ -82,6 +94,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Run the install script
         run: |
           ./ros2-jazzy-desktop-main.sh
@@ -94,6 +110,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Run the install script
         run: |
           ./ros2-kilted-ros-base-main.sh
@@ -107,6 +127,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Run the install script
         run: |
           ./ros2-kilted-desktop-main.sh

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: "0 1 * * 1"
 
+env:
+  PATH: /usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin
+
 jobs:
   os-check-on-ubuntu-jammy:
     runs-on: ubuntu-22.04
@@ -44,10 +47,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
       - name: Run the install script
         run: |
           ./ros2-humble-ros-base-main.sh
@@ -61,10 +60,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
       - name: Run the install script
         run: |
           ./ros2-humble-desktop-main.sh
@@ -77,10 +72,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Run the install script
         run: |
           ./ros2-jazzy-ros-base-main.sh
@@ -94,10 +85,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Run the install script
         run: |
           ./ros2-jazzy-desktop-main.sh
@@ -110,10 +97,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Run the install script
         run: |
           ./ros2-kilted-ros-base-main.sh
@@ -127,10 +110,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Run the install script
         run: |
           ./ros2-kilted-desktop-main.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Run the install script
         run: |
           sed -e 's/^\(CHOOSE_ROS_DISTRO=.*\)/#\1\nCHOOSE_ROS_DISTRO=humble/g' -i run.sh
@@ -35,6 +39,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Run the install script
         run: |
           sed -e 's/^\(CHOOSE_ROS_DISTRO=.*\)/#\1\nCHOOSE_ROS_DISTRO=jazzy/g' -i run.sh
@@ -48,6 +56,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python for ROS 2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Run the install script
         run: |
           sed -e 's/^\(CHOOSE_ROS_DISTRO=.*\)/#\1\nCHOOSE_ROS_DISTRO=kilted/g' -i run.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,15 +17,17 @@ on:
   schedule:
     - cron: "0 1 * * 1"
 
+env:
+  # Ensure the system Python (/usr/bin/python3) is used instead of
+  # the runner-managed one under /usr/local, which may lack ROS 2
+  # Python dependencies such as catkin_pkg.
+  PATH: /usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin
+
 jobs:
   humble:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
       - name: Run the install script
         run: |
           sed -e 's/^\(CHOOSE_ROS_DISTRO=.*\)/#\1\nCHOOSE_ROS_DISTRO=humble/g' -i run.sh
@@ -39,10 +41,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Run the install script
         run: |
           sed -e 's/^\(CHOOSE_ROS_DISTRO=.*\)/#\1\nCHOOSE_ROS_DISTRO=jazzy/g' -i run.sh
@@ -56,10 +54,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python for ROS 2
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Run the install script
         run: |
           sed -e 's/^\(CHOOSE_ROS_DISTRO=.*\)/#\1\nCHOOSE_ROS_DISTRO=kilted/g' -i run.sh


### PR DESCRIPTION
## Summary

- A GitHub Actions runner image update (`ubuntu22/20260105.207` → `ubuntu22/20260112.2`) caused all scheduled CI workflows to fail since 2026-01-19
- The runner's `/usr/local/bin/python3` took precedence over the system `/usr/bin/python3`, causing ROS 2 Python dependencies (e.g. `catkin_pkg`) to not be found, which made all rclpy packages fail with exit code 2 during `colcon test`
- Fixed by redefining `PATH` at the workflow level to prioritize `/usr/bin` over `/usr/local/bin`, ensuring the system Python is used

## What was tried

1. **`actions/setup-python` to pin the Python version** → Installed a separate Python under `/opt/hostedtoolcache` which lacked ROS 2 dependency packages, resulting in `ModuleNotFoundError: No module named 'catkin_pkg'` — made things worse
2. **`env.PATH` to prioritize system Python** → Success

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to set a global PATH for all jobs, changing which system binaries (including system Python) are resolved during runs.
  * No changes to job steps, install/test commands, or application code—only workflow-level environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->