### PR TITLE
feat: Add ROS 2 Lyrical installers

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -7,6 +7,7 @@ on:
       - "ros2-humble-**.sh"
       - "ros2-jazzy-**.sh"
       - "ros2-kilted-**.sh"
+      - "ros2-lyrical-**.sh"
       - ".github/workflows/installers.yml"
   pull_request:
     branches:
@@ -15,6 +16,7 @@ on:
       - "ros2-humble-**.sh"
       - "ros2-jazzy-**.sh"
       - "ros2-kilted-**.sh"
+      - "ros2-lyrical-**.sh"
       - ".github/workflows/installers.yml"
   schedule:
     - cron: "0 1 * * 1"

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -138,11 +138,11 @@ jobs:
       - name: Run the install script
         run: |
           ./ros2-lyrical-ros-base-main.sh
-      - name: Run smoke test
+      - name: Run the test script
         run: |
-          source /opt/ros/lyrical/setup.bash
-          ros2 pkg prefix rclcpp
-          ros2 interface show std_msgs/msg/String
+          sed -e 's/^\(ROS_DISTRO=.*\)/#\1\nROS_DISTRO=lyrical/g' -i tutorial.sh
+          sed -e 's/^\(source \/opt.*bash\)$/\1\nrosdep install -r -y -i --from-paths ./g' -i tutorial.sh
+          bash <(head -n -2 ./tutorial.sh)
 
   lyrical-desktop-main:
     runs-on: ubuntu-24.04
@@ -162,8 +162,7 @@ jobs:
       - name: Run the install script
         run: |
           ./ros2-lyrical-desktop-main.sh
-      - name: Run smoke test
+      - name: Run the test script
         run: |
-          source /opt/ros/lyrical/setup.bash
-          ros2 pkg prefix rclcpp
-          ros2 pkg prefix rviz2
+          sed -e 's/^\(ROS_DISTRO=.*\)/#\1\nROS_DISTRO=lyrical/g' -i tutorial.sh
+          bash <(head -n -2 ./tutorial.sh)

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -119,3 +119,51 @@ jobs:
         run: |
           sed -e 's/^\(ROS_DISTRO=.*\)/#\1\nROS_DISTRO=kilted/g' -i tutorial.sh
           bash <(head -n -2 ./tutorial.sh)
+
+  lyrical-ros-base-main:
+    runs-on: ubuntu-24.04
+    container: ubuntu:26.04
+    defaults:
+      run:
+        shell: bash
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      ROS_DISTRO: lyrical
+    steps:
+      - name: Install container prerequisites
+        run: |
+          apt-get update
+          apt-get install -y ca-certificates git sudo
+      - uses: actions/checkout@v6
+      - name: Run the install script
+        run: |
+          ./ros2-lyrical-ros-base-main.sh
+      - name: Run smoke test
+        run: |
+          source /opt/ros/lyrical/setup.bash
+          ros2 pkg prefix rclcpp
+          ros2 interface show std_msgs/msg/String
+
+  lyrical-desktop-main:
+    runs-on: ubuntu-24.04
+    container: ubuntu:26.04
+    defaults:
+      run:
+        shell: bash
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      ROS_DISTRO: lyrical
+    steps:
+      - name: Install container prerequisites
+        run: |
+          apt-get update
+          apt-get install -y ca-certificates git sudo
+      - uses: actions/checkout@v6
+      - name: Run the install script
+        run: |
+          ./ros2-lyrical-desktop-main.sh
+      - name: Run smoke test
+        run: |
+          source /opt/ros/lyrical/setup.bash
+          ros2 pkg prefix rclcpp
+          ros2 pkg prefix rviz2

--- a/.test/test-os-check-noble.bats
+++ b/.test/test-os-check-noble.bats
@@ -17,3 +17,9 @@ setup() {
 	[ "$status" -eq 1 ]
 	assert_output --partial "ERROR: This OS (version: noble) is not supported"
 }
+
+@test "Lyrical fail on Ubuntu 24.04" {
+	run ./ros2-lyrical-desktop-main.sh
+	[ "$status" -eq 1 ]
+	assert_output --partial "ERROR: This OS (version: noble) is not supported"
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ ROS 2 Kilted
 * To install `ros-kilted-ros-base`, use [`ros2-kilted-ros-base-main.sh`](./ros2-kilted-ros-base-main.sh) instead of `run.sh`.
 * To install `ros-kilted-desktop`, use [`ros2-kilted-desktop-main.sh`](./ros2-kilted-desktop-main.sh) instead of `run.sh`.
 
+ROS 2 Lyrical (LTS)
+
+* To install `ros-lyrical-ros-base`, use [`ros2-lyrical-ros-base-main.sh`](./ros2-lyrical-ros-base-main.sh) instead of `run.sh`.
+* To install `ros-lyrical-desktop`, use [`ros2-lyrical-desktop-main.sh`](./ros2-lyrical-desktop-main.sh) instead of `run.sh`.
+
 #### Old versions
 
 ROS 2 Dashing (EOL)
@@ -75,6 +80,7 @@ Reference: [REP-0003](https://ros.org/reps/rep-0003.html), [REP-2000](https://ro
 | Ubuntu 20.04<br>EOL: April 2025[^3] | Noetic<br>EOL: May 2025 | Foxy<br>EOL: May 2023 |
 | Ubuntu 22.04<br>EOL: April 2027[^4] | - | Humble<br>EOL: May 2027 |
 | Ubuntu 24.04<br>EOL: June 2029[^5] | - | Jazzy<br>EOL: May 2029 |
+| Ubuntu 26.04<br>EOL: May 2031[^6] | - | Lyrical<br>EOL: May 2031 |
 
 * Note: Here, EOL for Ubuntu refers to the end of normal support, which is not Ubuntu Pro.
 
@@ -82,6 +88,7 @@ Reference: [REP-0003](https://ros.org/reps/rep-0003.html), [REP-2000](https://ro
 [^3]: https://wiki.ubuntu.com/FocalFossa/ReleaseNotes
 [^4]: https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668
 [^5]: https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890
+[^6]: https://documentation.ubuntu.com/project/release-team/list-of-releases/
 
 ## LICENSE
 

--- a/ros2-lyrical-desktop-main.sh
+++ b/ros2-lyrical-desktop-main.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -eu
+
+# Copyright 2019-2026 Tiryoh
+# https://github.com/Tiryoh/ros2_setup_scripts_ubuntu
+# Licensed under the Apache License, Version 2.0
+#
+# REF: https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
+# by Open Robotics, licensed under CC-BY-4.0
+# source: https://github.com/ros2/ros2_documentation
+
+CHOOSE_ROS_DISTRO=lyrical
+INSTALL_PACKAGE=desktop
+TARGET_OS=resolute
+
+# Check OS version
+if ! which lsb_release > /dev/null ; then
+	sudo apt-get update
+	sudo apt-get install -y curl lsb-release
+fi
+
+if [[ "$(lsb_release -sc)" == "$TARGET_OS" ]]; then
+	echo "OS Check Passed"
+else
+	printf '\033[33m%s\033[m\n' "=================================================="
+	printf '\033[33m%s\033[m\n' "ERROR: This OS (version: $(lsb_release -sc)) is not supported"
+	printf '\033[33m%s\033[m\n' "=================================================="
+	exit 1
+fi
+
+ARCH=$(dpkg --print-architecture)
+if [[ "$ARCH" != "amd64" && "$ARCH" != "arm64" ]]; then
+	printf '\033[33m%s\033[m\n' "=================================================="
+	printf '\033[33m%s\033[m\n' "ERROR: This architecture ($ARCH) is not supported"
+	printf '\033[33m%s\033[m\n' "See https://www.ros.org/reps/rep-2000.html"
+	printf '\033[33m%s\033[m\n' "=================================================="
+	exit 1
+fi
+
+# Install
+sudo apt-get update
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository -y universe
+sudo apt-get install -y curl lsb-release build-essential
+
+ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
+curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
+sudo dpkg -i /tmp/ros2-apt-source.deb
+sudo apt-get update
+sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
+sudo apt-get install -y python3-argcomplete python3-colcon-clean
+sudo apt-get install -y python3-colcon-common-extensions
+sudo apt-get install -y python3-rosdep python3-vcstool
+[ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
+sudo rosdep init
+rosdep update
+grep -F "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" ~/.bashrc ||
+echo "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" >> ~/.bashrc
+# From ROS 2 Iron, it uses ROS_AUTOMATIC_DISCOVERY_RANGE instead of ROS_LOCALHOST_ONLY
+# https://docs.ros.org/en/iron/Releases/Release-Iron-Irwini.html#improved-discovery-options
+grep -F "export ROS_AUTOMATIC_DISCOVERY_RANGE=" ~/.bashrc ||
+echo "# export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST" >> ~/.bashrc
+
+set +u
+
+source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash
+
+echo "success installing ROS2 $CHOOSE_ROS_DISTRO"
+echo "Run 'source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash'"

--- a/ros2-lyrical-ros-base-main.sh
+++ b/ros2-lyrical-ros-base-main.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -eu
+
+# Copyright 2019-2026 Tiryoh
+# https://github.com/Tiryoh/ros2_setup_scripts_ubuntu
+# Licensed under the Apache License, Version 2.0
+#
+# REF: https://docs.ros.org/en/lyrical/Installation/Ubuntu-Install-Debs.html
+# by Open Robotics, licensed under CC-BY-4.0
+# source: https://github.com/ros2/ros2_documentation
+
+CHOOSE_ROS_DISTRO=lyrical
+INSTALL_PACKAGE=ros-base
+TARGET_OS=resolute
+
+# Check OS version
+if ! which lsb_release > /dev/null ; then
+	sudo apt-get update
+	sudo apt-get install -y curl lsb-release
+fi
+
+if [[ "$(lsb_release -sc)" == "$TARGET_OS" ]]; then
+	echo "OS Check Passed"
+else
+	printf '\033[33m%s\033[m\n' "=================================================="
+	printf '\033[33m%s\033[m\n' "ERROR: This OS (version: $(lsb_release -sc)) is not supported"
+	printf '\033[33m%s\033[m\n' "=================================================="
+	exit 1
+fi
+
+ARCH=$(dpkg --print-architecture)
+if [[ "$ARCH" != "amd64" && "$ARCH" != "arm64" ]]; then
+	printf '\033[33m%s\033[m\n' "=================================================="
+	printf '\033[33m%s\033[m\n' "ERROR: This architecture ($ARCH) is not supported"
+	printf '\033[33m%s\033[m\n' "See https://www.ros.org/reps/rep-2000.html"
+	printf '\033[33m%s\033[m\n' "=================================================="
+	exit 1
+fi
+
+# Install
+sudo apt-get update
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository -y universe
+sudo apt-get install -y curl lsb-release build-essential
+
+ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
+curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
+sudo dpkg -i /tmp/ros2-apt-source.deb
+sudo apt-get update
+sudo apt-get install -y ros-$CHOOSE_ROS_DISTRO-$INSTALL_PACKAGE
+sudo apt-get install -y python3-argcomplete python3-colcon-clean
+sudo apt-get install -y python3-colcon-common-extensions
+sudo apt-get install -y python3-rosdep python3-vcstool
+[ -e /etc/ros/rosdep/sources.list.d/20-default.list ] ||
+sudo rosdep init
+rosdep update
+grep -F "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" ~/.bashrc ||
+echo "source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash" >> ~/.bashrc
+# From ROS 2 Iron, it uses ROS_AUTOMATIC_DISCOVERY_RANGE instead of ROS_LOCALHOST_ONLY
+# https://docs.ros.org/en/iron/Releases/Release-Iron-Irwini.html#improved-discovery-options
+grep -F "export ROS_AUTOMATIC_DISCOVERY_RANGE=" ~/.bashrc ||
+echo "# export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST" >> ~/.bashrc
+
+set +u
+
+source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash
+
+echo "success installing ROS2 $CHOOSE_ROS_DISTRO"
+echo "Run 'source /opt/ros/$CHOOSE_ROS_DISTRO/setup.bash'"


### PR DESCRIPTION
## Summary
- add ROS 2 Lyrical install scripts for Ubuntu 26.04
- add GitHub Actions jobs that run the Lyrical installers in ubuntu:26.04 containers because GitHub-hosted Ubuntu 26.04 runners are not available yet
- run the existing tutorial.sh-based test flow for Lyrical ros-base and desktop jobs, matching the other supported ROS 2 distros

## Testing
- docker run ubuntu:26.04 ./ros2-lyrical-ros-base-main.sh, then run the tutorial.sh flow with ROS_DISTRO=lyrical and the ros-base rosdep insertion; colcon build/test completed successfully
- git diff --check

Note: GitHub Actions does not have a GitHub-hosted Ubuntu 26.04 runner yet, so the Lyrical checks run on ubuntu-24.04 with an ubuntu:26.04 container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated ROS 2 Lyrical desktop and base installers and Ubuntu 26.04 support.

* **Tests**
  * Added a test verifying the Lyrical desktop installer fails appropriately on an unsupported Ubuntu release.

* **Documentation**
  * Updated installation guide and supported-versions table to include ROS 2 Lyrical and Ubuntu 26.04.

* **Chores**
  * CI now runs jobs to exercise the Lyrical installers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->